### PR TITLE
Add development mode bypass for email sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /magiclink/magiclink.test
 /magiclink/mem.prof
 /level.db/
+/dev_bypass_emails.txt

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ config := magiclink.DefaultConfig()
 - `MaxLoginAttempts`: Maximum number of login attempts per email within the window (default: 5)
 - `RateLimitWindow`: Time window for rate limiting (default: 15 minutes)
 
+### Development Configuration
+
+- `DevBypassEmailFilePath`: Path to a file containing email addresses that should bypass email sending. This is useful for development and testing purposes. The file should contain one email address per line. If an email address in this file requests a magic link, the link will be returned in the response instead of being sent via email, allowing for easier testing of the authentication flow.
+
 ## API Reference
 
 ### Creating a New Instance
@@ -101,7 +105,7 @@ ml.RegisterHandlers(e)
 ```
 
 This registers the following endpoints:
-- `POST /auth/login`: Accepts an email address and sends a magic link
+- `POST /auth/login`: Accepts an email address and sends a magic link. If the email is in the bypass list (specified by `DevBypassEmailFilePath`), the magic link will be returned in the response as `magic_link` instead of being sent via email.
 - `GET /auth/verify`: Verifies a token from a magic link and creates a session
 - `POST /auth/logout`: Logs out the user by invalidating their session and redirects to the configured URL. You can override the redirect URL by adding a `redirect` query parameter (e.g., `/auth/logout?redirect=/login`)
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -52,6 +52,9 @@ func main() {
 	config.SMTPFromName = getEnv("SMTP_FROM_NAME", "Magic Link Example")
 	config.ServerAddr = getEnv("SERVER_ADDR", "http://localhost:8080")
 
+	// Set the path to the file containing email addresses that should bypass email sending
+	config.DevBypassEmailFilePath = getEnv("DEV_BYPASS_EMAIL_FILE", "dev_bypass_emails.txt")
+
 	// Set Japanese email subject and template
 	config.EmailSubject = "認証用マジックリンク"
 	config.EmailTemplate = `From: {{.FromName}} <{{.From}}>

--- a/examples/simple/templates/login.html
+++ b/examples/simple/templates/login.html
@@ -107,7 +107,19 @@
             .then(response => response.json())
             .then(data => {
                 if (data.message) {
-                    messageDiv.innerHTML = `<div class="alert alert-success">${data.message}</div>`;
+                    let messageHtml = `<div class="alert alert-success">${data.message}</div>`;
+                    
+                    // If there's a magic link in the response, display it
+                    if (data.magic_link) {
+                        messageHtml += `
+                            <div class="alert alert-success" style="margin-top: 10px;">
+                                <p>Magic Link for Development:</p>
+                                <a href="${data.magic_link}" class="magic-link" style="word-break: break-all;">${data.magic_link}</a>
+                            </div>
+                        `;
+                    }
+                    
+                    messageDiv.innerHTML = messageHtml;
                     document.getElementById('email').value = '';
                 } else if (data.error) {
                     messageDiv.innerHTML = `<div class="alert alert-danger">${data.error}</div>`;

--- a/magiclink/magiclink.go
+++ b/magiclink/magiclink.go
@@ -3,7 +3,10 @@
 package magiclink
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -32,6 +35,14 @@ type Config struct {
 	SMTPUseTLS      bool // Use TLS from the start (port 465)
 	SMTPUseSTARTTLS bool // Use STARTTLS (port 587)
 	SMTPSkipVerify  bool // Skip TLS certificate verification
+
+	// Development configuration
+	// DevBypassEmailFilePath is the path to a file containing email addresses that should bypass email sending.
+	// This is useful for development and testing purposes.
+	// The file should contain one email address per line.
+	// If an email address in this file requests a magic link, the link will be returned in the response
+	// instead of being sent via email, allowing for easier testing of the authentication flow.
+	DevBypassEmailFilePath string
 
 	// Token configuration
 	TokenExpiry time.Duration
@@ -62,40 +73,42 @@ type Config struct {
 // DefaultConfig returns a Config with sensible default values.
 func DefaultConfig() Config {
 	return Config{
-		DatabasePath:      "magiclink.db",
-		DatabaseType:      "sqlite",
-		DatabaseOptions:   map[string]string{},
-		SMTPPort:          587,
-		SMTPUseSTARTTLS:   true, // Default to STARTTLS for port 587
-		SMTPUseTLS:        false,
-		SMTPSkipVerify:    false,
-		TokenExpiry:       30 * time.Minute,
-		SessionExpiry:     7 * 24 * time.Hour, // 7 days
-		CookieName:        "session",
-		CookieSecure:      true,
-		CookieHTTPOnly:    true,
-		CookieSameSite:    "lax",
-		CookiePath:        "/",
-		LoginURL:          "/auth/login",
-		VerifyURL:         "/auth/verify",
-		RedirectURL:       "/",
-		LogoutRedirectURL: "/",
-		EmailSubject:      "Your Magic Link for Authentication",
-		ServerAddr:        "http://localhost:8080",
-		MaxLoginAttempts:  5,
-		RateLimitWindow:   15 * time.Minute,
+		DatabasePath:           "magiclink.db",
+		DatabaseType:           "sqlite",
+		DatabaseOptions:        map[string]string{},
+		SMTPPort:               587,
+		SMTPUseSTARTTLS:        true, // Default to STARTTLS for port 587
+		SMTPUseTLS:             false,
+		SMTPSkipVerify:         false,
+		DevBypassEmailFilePath: "", // Empty by default
+		TokenExpiry:            30 * time.Minute,
+		SessionExpiry:          7 * 24 * time.Hour, // 7 days
+		CookieName:             "session",
+		CookieSecure:           true,
+		CookieHTTPOnly:         true,
+		CookieSameSite:         "lax",
+		CookiePath:             "/",
+		LoginURL:               "/auth/login",
+		VerifyURL:              "/auth/verify",
+		RedirectURL:            "/",
+		LogoutRedirectURL:      "/",
+		EmailSubject:           "Your Magic Link for Authentication",
+		ServerAddr:             "http://localhost:8080",
+		MaxLoginAttempts:       5,
+		RateLimitWindow:        15 * time.Minute,
 	}
 }
 
 // MagicLink is the main struct that holds the configuration and provides
 // methods for the magic link authentication system.
 type MagicLink struct {
-	Config         Config
-	Echo           *echo.Echo
-	DB             storage.Database
-	TokenManager   *token.Manager
-	EmailSender    *email.Sender
-	SessionManager *session.Manager
+	Config          Config
+	Echo            *echo.Echo
+	DB              storage.Database
+	TokenManager    *token.Manager
+	EmailSender     *email.Sender
+	SessionManager  *session.Manager
+	DevBypassEmails map[string]bool // Map of email addresses that should bypass email sending
 }
 
 // New creates a new MagicLink instance with the provided configuration.
@@ -152,13 +165,24 @@ func New(config Config) (*MagicLink, error) {
 	}
 	sessionManager := session.New(database, sessionConfig)
 
-	return &MagicLink{
-		Config:         config,
-		DB:             database,
-		TokenManager:   tokenManager,
-		EmailSender:    emailSender,
-		SessionManager: sessionManager,
-	}, nil
+	// Create the MagicLink instance
+	ml := &MagicLink{
+		Config:          config,
+		DB:              database,
+		TokenManager:    tokenManager,
+		EmailSender:     emailSender,
+		SessionManager:  sessionManager,
+		DevBypassEmails: make(map[string]bool),
+	}
+
+	// Load the bypass email addresses if a file path is provided
+	if config.DevBypassEmailFilePath != "" {
+		if err := ml.loadDevBypassEmails(config.DevBypassEmailFilePath); err != nil {
+			return nil, fmt.Errorf("failed to load bypass email addresses: %w", err)
+		}
+	}
+
+	return ml, nil
 }
 
 // RegisterHandlers registers the necessary handlers with the Echo instance.
@@ -171,6 +195,9 @@ func (m *MagicLink) RegisterHandlers(e *echo.Echo) {
 		m.EmailSender,
 		m.Config.MaxLoginAttempts,
 		m.Config.RateLimitWindow,
+		m.DevBypassEmails,
+		m.Config.ServerAddr,
+		m.Config.VerifyURL,
 	))
 
 	e.GET(m.Config.VerifyURL, handlers.VerifyHandler(
@@ -215,4 +242,45 @@ func (m *MagicLink) CleanupExpiredSessions() error {
 // Close closes the database connection and cleans up resources.
 func (m *MagicLink) Close() error {
 	return m.DB.Close()
+}
+
+// loadDevBypassEmails reads the file at the given path and loads the email addresses into the DevBypassEmails map.
+// Each line in the file should contain a single email address.
+func (m *MagicLink) loadDevBypassEmails(filePath string) error {
+	// Initialize the map
+	m.DevBypassEmails = make(map[string]bool)
+
+	// If no file path is provided, return early
+	if filePath == "" {
+		return nil
+	}
+
+	// Open the file
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open bypass email file: %w", err)
+	}
+	defer file.Close()
+
+	// Read the file line by line
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		// Get the line and trim whitespace
+		email := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines
+		if email == "" {
+			continue
+		}
+
+		// Add the email to the map
+		m.DevBypassEmails[email] = true
+	}
+
+	// Check for errors
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading bypass email file: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

- Adds a development mode bypass for email sending by introducing the `DevBypassEmailFilePath`. This allows specifying a file containing email addresses that bypass email sending.
- When an email is in the bypass list, the generated magic link is returned in the login endpoint response.
- Enhances error handling for file closing in the `loadDevBypassEmails` function and improves variable naming for clarity.
- Displays the magic link in the login response for development mode.
- Updates relevant documentation, examples, and `.gitignore`.
- Implements logic to load and process bypass email addresses during initialization.

### Checklist

- [ ] Tests have been added or updated as needed.
- [ ] Relevant documentation has been added or updated.
- [ ] Changes have been tested locally.