### PR TITLE
Add email preview functionality and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,14 @@ customData := &CustomEmailData{
 }
 
 // Send email with custom template and data
-err := ml.EmailSender.SendMagicLinkWithTemplateAndData(
+_, err := ml.EmailSender.SendMagicLinkWithTemplateAndData(
     "user@example.com",           // to
     token,                        // token
     30,                          // expiryMinutes
     "Your Order Confirmation",    // subject
     customTemplate,              // template
     customData,                  // data
+    false,                       // dryRun
 )
 ```
 
@@ -189,12 +190,57 @@ The following macros are automatically populated in the `BaseTemplateData`:
 - `{{.MagicLink}}` - Generated magic link URL
 - `{{.ExpiryMinutes}}` - Token expiry time in minutes
 
+#### Dry Run Mode
+
+The `SendMagicLinkWithTemplateAndData` method supports a dry run mode that allows you to preview the expanded email template without actually sending the email. This is useful for testing templates, debugging, and development purposes.
+
+When dry run mode is enabled (by setting the `dryRun` parameter to `true`), the method:
+- Expands the template with the provided data
+- Returns the complete email content as a string (including headers)
+- Does **not** send the actual email
+
+```go
+// Enable dry run mode to preview the email content
+previewContent, err := ml.EmailSender.SendMagicLinkWithTemplateAndData(
+    "user@example.com",           // to
+    token,                        // token
+    30,                          // expiryMinutes
+    "Your Order Confirmation",    // subject
+    customTemplate,              // template
+    customData,                  // data
+    true,                        // dryRun - enable preview mode
+)
+if err != nil {
+    log.Printf("Template expansion failed: %v", err)
+    return
+}
+
+// previewContent now contains the expanded email template
+fmt.Println("Email Preview:")
+fmt.Println(previewContent)
+```
+
+##### Use Cases for Dry Run Mode
+
+- **Template Testing**: Verify that your custom templates expand correctly with real data
+- **Development**: Test email functionality without sending actual emails
+- **Debugging**: Inspect the final email content to troubleshoot formatting issues
+- **Content Validation**: Review email content before sending to ensure accuracy
+
+##### Email Test Example Integration
+
+The [email-test example](examples/email-test) includes a web interface that demonstrates dry run functionality:
+
+- Check the "Preview mode (dry run - don't send email)" checkbox in the form
+- The preview content will be displayed in a modal dialog
+- This allows you to test different templates and data combinations interactively
+
 #### Error Handling
 
 The method validates that your data structure embeds `BaseTemplateData`. If not, it returns an error:
 
 ```go
-err := ml.EmailSender.SendMagicLinkWithTemplateAndData(to, token, expiry, subject, template, data)
+previewContent, err := ml.EmailSender.SendMagicLinkWithTemplateAndData(to, token, expiry, subject, template, data, dryRun)
 if err != nil {
     // Handle validation errors like:
     // "data parameter must embed BaseTemplateData struct"

--- a/examples/email-test/templates/email-form.html
+++ b/examples/email-test/templates/email-form.html
@@ -74,6 +74,47 @@
             background-color: #f2dede;
             border-color: #ebccd1;
         }
+        .modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0,0,0,0.5);
+        }
+        .modal-content {
+            background-color: white;
+            margin: 15% auto;
+            padding: 20px;
+            border: 1px solid #888;
+            width: 80%;
+            max-width: 600px;
+            border-radius: 5px;
+        }
+        .close {
+            color: #aaa;
+            float: right;
+            font-size: 28px;
+            font-weight: bold;
+            cursor: pointer;
+        }
+        .close:hover,
+        .close:focus {
+            color: black;
+            text-decoration: none;
+        }
+        .preview-content {
+            background-color: #f9f9f9;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            max-height: 400px;
+            overflow-y: auto;
+        }
     </style>
 </head>
 <body>
@@ -97,6 +138,12 @@
             <div class="form-group">
                 <label for="body">Message Body:</label>
                 <textarea id="body" name="body" required></textarea>
+            </div>
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" id="preview" name="preview" value="true">
+                    Preview mode (dry run - don't send email)
+                </label>
             </div>
             <button type="submit" class="btn">Send Standard Email</button>
         </form>
@@ -133,17 +180,50 @@
                 <label for="amount">Amount (¥):</label>
                 <input type="number" id="amount" name="amount" step="0.01" min="0" required>
             </div>
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" id="customPreview" name="preview" value="true">
+                    Preview mode (dry run - don't send email)
+                </label>
+            </div>
             <button type="submit" class="btn btn-secondary">Send Custom Email</button>
         </form>
     </div>
 
+    <!-- Modal for preview -->
+    <div id="previewModal" class="modal">
+        <div class="modal-content">
+            <span class="close" onclick="closePreviewModal()">&times;</span>
+            <h2>Email Preview (Dry Run)</h2>
+            <div id="previewContent" class="preview-content"></div>
+        </div>
+    </div>
+
     <script>
+        function showPreviewModal(content) {
+            document.getElementById('previewContent').textContent = content;
+            document.getElementById('previewModal').style.display = 'block';
+        }
+
+        function closePreviewModal() {
+            document.getElementById('previewModal').style.display = 'none';
+        }
+
+        // Close modal when clicking outside of it
+        window.onclick = function(event) {
+            const modal = document.getElementById('previewModal');
+            if (event.target == modal) {
+                modal.style.display = 'none';
+            }
+        }
+
         document.getElementById('emailForm').addEventListener('submit', function(e) {
             e.preventDefault();
             
             const to = document.getElementById('to').value;
             const subject = document.getElementById('subject').value;
             const body = document.getElementById('body').value;
+            const preview = document.getElementById('preview').checked;
             const messageDiv = document.getElementById('message');
             
             fetch('/send-email', {
@@ -154,12 +234,17 @@
                 body: JSON.stringify({ 
                     to: to,
                     subject: subject,
-                    body: body
+                    body: body,
+                    preview: preview
                 }),
             })
             .then(response => response.json())
             .then(data => {
-                if (data.message) {
+                if (data.preview_content) {
+                    // Show preview in modal for dry run mode
+                    showPreviewModal(data.preview_content);
+                    messageDiv.innerHTML = `<div class="alert alert-success">Email preview generated successfully</div>`;
+                } else if (data.message) {
                     let messageHtml = `<div class="alert alert-success">${data.message}</div>`;
                     
                     // If there's a magic link in the response, display it
@@ -193,6 +278,7 @@
             const userName = document.getElementById('userName').value;
             const orderID = document.getElementById('orderID').value;
             const amount = parseFloat(document.getElementById('amount').value);
+            const customPreview = document.getElementById('customPreview').checked;
             const customMessageDiv = document.getElementById('customMessage');
             
             fetch('/send-custom-email', {
@@ -206,12 +292,17 @@
                     body: customBody,
                     user_name: userName,
                     order_id: orderID,
-                    amount: amount
+                    amount: amount,
+                    preview: customPreview
                 }),
             })
             .then(response => response.json())
             .then(data => {
-                if (data.message) {
+                if (data.preview_content) {
+                    // Show preview in modal for dry run mode
+                    showPreviewModal(data.preview_content);
+                    customMessageDiv.innerHTML = `<div class="alert alert-success">Custom email preview generated successfully</div>`;
+                } else if (data.message) {
                     let messageHtml = `<div class="alert alert-success">${data.message}</div>`;
                     
                     // If there's a magic link in the response, display it


### PR DESCRIPTION
```
### What does this PR do?

This pull request introduces the following changes:
- **Adds dry run (email preview) functionality**:
  - Updates the `email-test` example to include preview mode for both standard and custom email forms.
  - Implements a modal-based UI for displaying email content previews.
  - Updates backend logic in `SendMagicLinkWithTemplateAndData` to support email generation in preview mode.
  - Ensures a seamless user experience with style and JavaScript enhancements.
- **Expands the README**:
  - Documents how to use dry run mode for template testing, debugging, or content review.
  - Provides step-by-step instructions and examples for enhanced usability.

### Additional Context / Screenshots

*No additional context or screenshots provided.*

---

### Checklist:
- [ ] I have manually tested related features.
- [ ] I have added/updated test coverage where applicable.
- [ ] I have updated the documentation as needed.

```